### PR TITLE
fixed a missing quotes syntax error in the install packages part

### DIFF
--- a/tasks/main.yaml
+++ b/tasks/main.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Install openscap client packages
   yum:
-    name: {{ item }}
+    name: "{{ item }}"
     state: present
   with_items:
     - openscap-scanner


### PR DESCRIPTION
This fixes a missing quotes syntax error in the install packages part when running it with Ansible 2.4.2.0.